### PR TITLE
Support dynamic assets and load-more in fullscreen

### DIFF
--- a/Immich-Viewer/ViewModels/FullScreenImageViewModel.swift
+++ b/Immich-Viewer/ViewModels/FullScreenImageViewModel.swift
@@ -18,11 +18,12 @@ class FullScreenImageViewModel: ObservableObject {
     
     // MARK: - Configuration
     let initialAsset: ImmichAsset
-    let assets: [ImmichAsset]
+    private(set) var assets: [ImmichAsset]
     let initialIndex: Int
     
     // MARK: - Callbacks
     var onCurrentIndexChanged: ((Int) -> Void)?
+    var onNeedMoreAssets: (() -> Void)?
     
     // MARK: - Internal State
     private var currentIndex: Int
@@ -130,9 +131,21 @@ class FullScreenImageViewModel: ObservableObject {
         debugLog("FullScreenImageViewModel: Right navigation triggered (current: \(currentIndex), total: \(assets.count))")
         if canNavigateRight {
             navigateToImage(at: currentIndex + 1)
+            if currentIndex >= assets.count - 5 {
+                onNeedMoreAssets?()
+            }
         } else {
-            debugLog("FullScreenImageViewModel: Already at last photo, cannot navigate further")
+            debugLog("FullScreenImageViewModel: At last loaded photo, requesting more assets")
+            onNeedMoreAssets?()
         }
+    }
+    
+    /// Updates the asset list with newly loaded assets from the grid,
+    /// preserving the current navigation position
+    func updateAssets(_ newAssets: [ImmichAsset]) {
+        guard newAssets.count > assets.count else { return }
+        debugLog("FullScreenImageViewModel: Updating assets from \(assets.count) to \(newAssets.count)")
+        assets = newAssets
     }
     
     /// Toggles the EXIF info overlay

--- a/Immich-Viewer/Views/AssetGridView.swift
+++ b/Immich-Viewer/Views/AssetGridView.swift
@@ -103,11 +103,14 @@ struct AssetGridView: View {
             if let selectedAsset = viewModel.selectedAsset {
                 FullScreenImageView(
                     asset: selectedAsset,
-                    assets: viewModel.assets,
+                    assets: $viewModel.assets,
                     currentIndex: viewModel.assets.firstIndex(of: selectedAsset) ?? 0,
                     assetService: assetService,
                     authenticationService: authService,
-                    currentAssetIndex: $viewModel.currentAssetIndex
+                    currentAssetIndex: $viewModel.currentAssetIndex,
+                    onNeedMoreAssets: { [weak viewModel] in
+                        viewModel?.debouncedLoadMore()
+                    }
                 )
             }
         }

--- a/Immich-Viewer/Views/FullScreenImageView.swift
+++ b/Immich-Viewer/Views/FullScreenImageView.swift
@@ -10,6 +10,7 @@ struct FullScreenImageView: View {
     
     // MARK: - Bindings
     @Binding var currentAssetIndex: Int
+    @Binding var liveAssets: [ImmichAsset]
     
     // MARK: - Environment
     @Environment(\.dismiss) private var dismiss
@@ -19,22 +20,28 @@ struct FullScreenImageView: View {
     
     // MARK: - Initialization
     
+    // MARK: - Callbacks
+    private let onNeedMoreAssets: (() -> Void)?
+    
     init(
         asset: ImmichAsset,
-        assets: [ImmichAsset],
+        assets: Binding<[ImmichAsset]>,
         currentIndex: Int,
         assetService: AssetService,
         authenticationService: AuthenticationService,
-        currentAssetIndex: Binding<Int>
+        currentAssetIndex: Binding<Int>,
+        onNeedMoreAssets: (() -> Void)? = nil
     ) {
         debugLog("FullScreenImageView: Initializing with currentIndex: \(currentIndex)")
         self.assetService = assetService
         self.authenticationService = authenticationService
         self._currentAssetIndex = currentAssetIndex
+        self._liveAssets = assets
+        self.onNeedMoreAssets = onNeedMoreAssets
         
         _viewModel = StateObject(wrappedValue: FullScreenImageViewModel(
             asset: asset,
-            assets: assets,
+            assets: assets.wrappedValue,
             currentIndex: currentIndex,
             assetService: assetService
         ))
@@ -74,10 +81,13 @@ struct FullScreenImageView: View {
             onDismiss: { dismiss() }
         ))
         .onAppear {
-            // Set up the callback to sync currentAssetIndex binding
             viewModel.onCurrentIndexChanged = { [self] newIndex in
                 self.currentAssetIndex = newIndex
             }
+            viewModel.onNeedMoreAssets = onNeedMoreAssets
+        }
+        .onChange(of: liveAssets.count) { _, _ in
+            viewModel.updateAssets(liveAssets)
         }
     }
     
@@ -488,7 +498,7 @@ struct VideoThumbnailView: View {
     
     FullScreenImageView(
         asset: sampleAsset,
-        assets: sampleAssets,
+        assets: .constant(sampleAssets),
         currentIndex: 0,
         assetService: assetService,
         authenticationService: authenticationService,

--- a/Immich-Viewer/Views/SearchView.swift
+++ b/Immich-Viewer/Views/SearchView.swift
@@ -78,7 +78,7 @@ struct SearchView: View {
             if let selectedAsset = viewModel.selectedAsset {
                 FullScreenImageView(
                     asset: selectedAsset,
-                    assets: viewModel.assets,
+                    assets: $viewModel.assets,
                     currentIndex: viewModel.assets.firstIndex(of: selectedAsset) ?? 0,
                     assetService: assetService,
                     authenticationService: authService,

--- a/Immich-Viewer/Views/WorldMapView.swift
+++ b/Immich-Viewer/Views/WorldMapView.swift
@@ -545,7 +545,7 @@ struct ClusterDetailView: View {
             if let asset = selectedAsset {
                 FullScreenImageView(
                     asset: asset,
-                    assets: cluster.assets,
+                    assets: .constant(cluster.assets),
                     currentIndex: currentAssetIndex,
                     assetService: assetService,
                     authenticationService: authService,


### PR DESCRIPTION
Allow the full-screen viewer to work with a live, updatable asset list and request more assets when nearing the end. FullScreenImageViewModel.assets is now private(set); a onNeedMoreAssets callback is added and invoked when navigating within 5 items of the end (or at the last loaded item). updateAssets(_:) lets the view model accept newly loaded assets while preserving the current position. FullScreenImageView now accepts a Binding<[ImmichAsset]> (liveAssets), wires the onNeedMoreAssets callback into the view model, and updates the view model when liveAssets.count changes. Call sites (AssetGridView, SearchView, WorldMapView) were updated to pass bindings or constants as appropriate; AssetGridView triggers debouncedLoadMore() via the new callback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core fullscreen navigation behavior and introduces automatic load-more triggers, which could impact paging correctness or cause redundant fetches if thresholds/callback wiring are off.
> 
> **Overview**
> Enables the fullscreen viewer to work against a *live* asset array and proactively trigger pagination when the user navigates near the end of the currently loaded items.
> 
> `FullScreenImageViewModel` now exposes `assets` as `private(set)`, adds `onNeedMoreAssets` and calls it when navigating within 5 items of the end (and when attempting to move past the last loaded item), and introduces `updateAssets(_:)` to accept newly loaded assets without disrupting the current position.
> 
> `FullScreenImageView` now takes `assets` as a `Binding<[ImmichAsset]>`, forwards the load-more callback into the view model, and refreshes the view model’s asset list when the bound array grows; call sites were updated to pass bindings where available (grid/search) and `.constant(...)` where not (map/preview), with `AssetGridView` wiring the callback to `debouncedLoadMore()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b580c0c6847b6af1caffb7dc8537cc7eddeee6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->