### PR TITLE
Prefer cached person thumbnail in People provider

### DIFF
--- a/Immich-Viewer/Components/ThumbnailProviders.swift
+++ b/Immich-Viewer/Components/ThumbnailProviders.swift
@@ -41,15 +41,30 @@ class AlbumThumbnailProvider: ThumbnailProvider {
 // MARK: - People Thumbnail Provider
 @MainActor
 class PeopleThumbnailProvider: ThumbnailProvider {
+    private let peopleService: PeopleService
     private let assetService: AssetService
     private var thumbnailCache: ThumbnailCache { ThumbnailCache.shared }
     
-    init(assetService: AssetService) {
+    init(peopleService: PeopleService, assetService: AssetService) {
+        self.peopleService = peopleService
         self.assetService = assetService
     }
     
     func loadThumbnails(for item: any GridDisplayable) async -> [UIImage] {
         guard let person = item as? Person else { return [] }
+        
+        let cacheKey = "person-\(person.id)"
+        
+        do {
+            let thumbnail = try await thumbnailCache.getThumbnail(for: cacheKey, size: "thumbnail") {
+                try await self.peopleService.loadPersonThumbnail(personId: person.id)
+            }
+            if let thumbnail = thumbnail {
+                return [thumbnail]
+            }
+        } catch {
+            debugLog("Failed to load person thumbnail for \(person.id), falling back to asset thumbnail: \(error)")
+        }
         
         do {
             let searchResult = try await assetService.fetchAssets(page: 1, limit: 1, personId: person.id)
@@ -62,7 +77,7 @@ class PeopleThumbnailProvider: ThumbnailProvider {
                 return [thumbnail]
             }
         } catch {
-            debugLog("Failed to fetch assets for person \(person.id): \(error)")
+            debugLog("Failed to fetch fallback asset for person \(person.id): \(error)")
         }
         return []
     }

--- a/Immich-Viewer/Views/PeopleGridView.swift
+++ b/Immich-Viewer/Views/PeopleGridView.swift
@@ -11,7 +11,7 @@ struct PeopleGridView: View {
     
     // MARK: - Thumbnail Provider
     private var thumbnailProvider: PeopleThumbnailProvider {
-        PeopleThumbnailProvider(assetService: assetService)
+        PeopleThumbnailProvider(peopleService: peopleService, assetService: assetService)
     }
     
     // MARK: - Initialization


### PR DESCRIPTION
Inject PeopleService into PeopleThumbnailProvider and try to load a cached person thumbnail first via ThumbnailCache (keyed by "person-<id>"). If that fails, fall back to fetching the person's first image asset as before. Updated initializer and call site in PeopleGridView to pass peopleService, and clarified a debug log message for the fallback asset error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to thumbnail loading order and dependency injection; main risk is incorrect caching key/behavior causing missing thumbnails or extra network calls.
> 
> **Overview**
> Updates `PeopleThumbnailProvider` to inject `PeopleService` and **prefer a dedicated person thumbnail** (cached under `person-<id>` via `ThumbnailCache`) before falling back to the previous behavior of fetching the person’s first image asset thumbnail.
> 
> Updates `PeopleGridView` to pass `peopleService` into the provider and tweaks the fallback error log message for clarity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11d23a95679fe79f7a9c88a9ea510bbb8c83ea89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->